### PR TITLE
fix: do not fetch contributors for uncommitted content

### DIFF
--- a/layouts/partials/hb/modules/revision/index.html
+++ b/layouts/partials/hb/modules/revision/index.html
@@ -29,7 +29,7 @@
       {{- $editURL = printf "https://github.com/%s/%s/edit/%s/%s" $params.repo_owner $params.repo_name $repoBranch $path }}
       {{- $viewURL = printf "https://github.com/%s/%s/blob/%s/%s" $params.repo_owner $params.repo_name $repoBranch $path }}
       {{- $historyURL = printf "https://github.com/%s/%s/commits/%s/%s" $params.repo_owner $params.repo_name $repoBranch $path }}
-      {{- if $showContributors }}
+      {{- if and $showContributors .GitInfo }}
         {{- $opts := dict "key" $.Lastmod }}
         {{- with getenv "GITHUB_TOKEN" }}
           {{- $opts = merge $opts (dict "headers" (dict "Authorization" (printf "Bearer %s" .))) }}


### PR DESCRIPTION
You'll need to enable [GitInfo](https://gohugo.io/methods/page/gitinfo/) feature via setting the `enableGitInfo` parameter on configuration file or specify the `--enableGitInfo` flag to `hugo` command.

Closes #110